### PR TITLE
Typo in syntax for Wand list-item

### DIFF
--- a/_feat-types/item-creation.md
+++ b/_feat-types/item-creation.md
@@ -16,7 +16,7 @@ Using an item creation feat also requires access to a laboratory or magical work
 
 - Scrolls: Base price = spell level × caster level × 25 gp.
 - Potions: Base price = spell level × caster level × 50 gp.
-= Wands: Base price = spell level × caster level × 750 gp.
+- Wands: Base price = spell level × caster level × 750 gp.
 
 **Staves:** The price for staves is calculated using more complex formulas (see the magic item creation system).
 


### PR DESCRIPTION
Wand had = instead of - to list as list-item properly, causing it not to show properly.